### PR TITLE
Also use --process-dependency-links on Ubuntu slaves.

### DIFF
--- a/lib/bootstrap.py
+++ b/lib/bootstrap.py
@@ -379,7 +379,8 @@ def bootstrap_jenkins_slave_ubuntu14():
         git_clone('https://github.com/ClusterHQ/flocker.git', 'flocker')
         with cd('flocker'):
             run('pip install --quiet --user .')
-            run('pip install --quiet --user "Flocker[dev]"')
+            run('pip install --quiet --user'
+                ' --process-dependency-links ".[dev]"')
             run('pip install --quiet --user python-subunit junitxml')
 
         # nginx is used during the acceptance tests, the VM built by


### PR DESCRIPTION
The earlier fix for --process-dependency-links was
incomplete because I missed that the command was duplicated
for Ubuntu slaves.