### PR TITLE
Refactor CI-slave-images to support GCE jenkins slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ For Rackspace:
     * OS_NO_CACHE
 
 
+For Google Compute Engine:
+
+    * GCE_PUBLIC_KEY_FILENAME
+
+    * GCE_PRIVATE_KEY_FILENAME
+
+    * OS_USERNAME
+
+
 create your virtualenv:
 
 ```
@@ -212,7 +221,3 @@ needs to be re-provisioned after your PR is accepted.
 
 
 9. Close the JIRA and its subtasks
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ For Rackspace:
 
 For Google Compute Engine:
 
-    * GCE_PUBLIC_KEY_FILENAME
+    * GCE_PUBLIC_KEY (Absolute file path to a public ssh key to use)
 
-    * GCE_PRIVATE_KEY_FILENAME
+    * GCE_PRIVATE_KEY (Absolute file path to a private ssh key to use)
 
-    * OS_USERNAME
+    * GCE_PROJECT (The GCE project to create the image in)
+
+    * GCE_ZONE (The GCE zone to use to make the image)
+
+    * GCE_MACHINE_TYPE (The machine type to use to make the image, defaults to
+                        n1-standard-2)
+
+
 
 
 create your virtualenv:
@@ -72,6 +79,8 @@ then execute as:
     fab it:cloud=ec2,distribution=centos7
     fab destroy
     fab it:cloud=rackspace,distribution=ubuntu14.04
+    fab destroy
+    fab it:cloud=gce,distribution=ubuntu14.04
 
     fab help
 
@@ -92,6 +101,9 @@ then execute as:
 
 The fab code should bootstrap an AWS/Rackspace instance,
 provision it and bake an image before deleting the original instance.
+
+On GCE it also bootstraps a GCE instance, but destroys the instance prior to
+constructing the image from the disk, as required by the GCE API.
 
 NOTE: if you get an:
 ```
@@ -120,7 +132,9 @@ Updating Jenkins to use the new images:
     fab it:cloud=ec2,distribution=centos7 \
         it:cloud=ec2,distribution=ubuntu14.04 \
         it:cloud=rackspace,distribution=centos7 \
-        it:cloud=rackspace,distribution=ubuntu14.04 | tee /tmp/fabbing.it.log
+        it:cloud=rackspace,distribution=ubuntu14.04 \
+        it:cloud=gce,distribution=centos7 \
+        it:cloud=gce,distribution=ubuntu14.04 | tee /tmp/fabbing.it.log
 
 
 2. Gather the IDs for the different images:

--- a/fabfile.py
+++ b/fabfile.py
@@ -72,8 +72,8 @@ def create_image():
     else:
         kwargs = dict(
             region=data['region'],
-            access_key_id=C[cloud_type][distribution]['access_key_id'],
-            secret_access_key=C[cloud_type][distribution]['secret_access_key'],
+            access_key_id=C[cloud_type][distribution]['creation_args']['access_key_id'],
+            secret_access_key=C[cloud_type][distribution]['creation_args']['secret_access_key'],
             instance_id=data['id'],
             name=description + "_" + date,
         )
@@ -102,8 +102,8 @@ def destroy():
                   disk_name=disk_name)
     else:
         region = data['region']
-        access_key_id = C[cloud_type][distribution]['access_key_id']
-        secret_access_key = C[cloud_type][distribution]['secret_access_key']
+        access_key_id = C[cloud_type][distribution]['creation_args']['access_key_id']
+        secret_access_key = C[cloud_type][distribution]['creation_args']['secret_access_key']
         instance_id = data['id']
 
         f_destroy(cloud=cloud_type,
@@ -127,8 +127,8 @@ def down(cloud=None):
     else:
         region = data['region']
         distribution = data['distribution'] + data['os_release']['VERSION_ID']
-        access_key_id = C[cloud_type][distribution]['access_key_id']
-        secret_access_key = C[cloud_type][distribution]['secret_access_key']
+        access_key_id = C[cloud_type][distribution]['creation_args']['access_key_id']
+        secret_access_key = C[cloud_type][distribution]['creation_args']['secret_access_key']
         instance_id = data['id']
         env.key_filename = C[cloud_type][distribution]['key_filename']
 
@@ -279,8 +279,8 @@ def status():
                  data=data)
     else:
         region = data['region']
-        access_key_id = C[cloud_type][distribution]['access_key_id']
-        secret_access_key = C[cloud_type][distribution]['secret_access_key']
+        access_key_id = C[cloud_type][distribution]['creation_args']['access_key_id']
+        secret_access_key = C[cloud_type][distribution]['creation_args']['secret_access_key']
         instance_id = data['id']
 
         setup_cloud_env(cloud_type)
@@ -347,8 +347,8 @@ def up(cloud=None, distribution=None):
             username = data['username']
             distribution = data['distribution'] + data['os_release']['VERSION_ID']
             region = data['region']
-            access_key_id = C[cloud_type][distribution]['access_key_id']
-            secret_access_key = C[cloud_type][distribution]['secret_access_key']
+            access_key_id = C[cloud_type][distribution]['creation_args']['access_key_id']
+            secret_access_key = C[cloud_type][distribution]['creation_args']['secret_access_key']
             instance_id = data['id']
             env.user = data['username']
             env.key_filename = C[cloud_type][distribution]['key_filename']

--- a/fabfile.py
+++ b/fabfile.py
@@ -37,6 +37,17 @@ from lib.bootstrap import (bootstrap_jenkins_slave_centos7,
 from tests.acceptance import acceptance_tests
 
 
+def setup_cloud_env(cloud_type):
+    if cloud_type == 'ec2':
+        ec2()
+    elif cloud_type == 'rackspace':
+        rackspace()
+    elif cloud_type == 'gce':
+        gce()
+    else:
+        raise ValueError("Unknown cloud type: {}".format(cloud_type))
+
+
 @task
 def create_image():
     """ create ami/image for either AWS, Rackspace or GCE """
@@ -93,10 +104,7 @@ def down(cloud=None):
     instance_id = data['id']
     env.key_filename = C[cloud_type][distribution]['key_filename']
 
-    if data['cloud_type'] == 'ec2':
-        ec2()
-    if data['cloud_type'] == 'rackspace':
-        rackspace()
+    setup_cloud_env(cloud_type)
     f_down(cloud=cloud_type,
            instance_id=instance_id,
            region=region,
@@ -180,15 +188,7 @@ def it(cloud, distribution):
     :param string cloud: The cloud type to use 'ec2', 'rackspace'
     :param string distribution: which OS to use 'centos7', 'ubuntu1404'
     """
-    if cloud == 'ec2':
-        ec2()
-    elif cloud == 'rackspace':
-        rackspace()
-    elif cloud == 'gce':
-        gce()
-    else:
-        ValueError("Unknown cloud specified {}".format(cloud))
-
+    setup_cloud_env(cloud)
     up(cloud=cloud, distribution=distribution)
     bootstrap(distribution)
     tests()
@@ -237,11 +237,7 @@ def status():
     env.user = data['username']
     env.key_filename = C[cloud_type][distribution]['key_filename']
 
-    if data['cloud_type'] == 'ec2':
-        ec2()
-    if data['cloud_type'] == 'rackspace':
-        rackspace()
-
+    setup_cloud_env(cloud_type)
     f_status(cloud=cloud_type,
              region=region,
              instance_id=instance_id,
@@ -283,13 +279,7 @@ def tests():
     instance_id = data['id']
     env.user = data['username']
     env.key_filename = C[cloud_type][distribution]['key_filename']
-
-    if data['cloud_type'] == 'ec2':
-        ec2()
-    elif data['cloud_type'] == 'rackspace':
-        rackspace()
-    elif data['cloud_type'] == 'gce':
-        gce()
+    setup_cloud_env(cloud_type)
 
     acceptance_tests(cloud=cloud_type,
                      region=region,
@@ -320,11 +310,7 @@ def up(cloud=None, distribution=None):
         env.user = data['username']
         env.key_filename = C[cloud_type][distribution]['key_filename']
 
-        if data['cloud_type'] == 'ec2':
-            ec2()
-        if data['cloud_type'] == 'rackspace':
-            rackspace()
-
+        setup_cloud_env(cloud_type)
         f_up(cloud=cloud_type,
              region=region,
              instance_id=instance_id,
@@ -513,7 +499,8 @@ if 'gce' in list_of_clouds:
             # 'tags': {'name': 'jenkins_slave_centos7_ondemand'}
         # },
         'ubuntu14.04': {
-            'base_image': 'ubuntu-14-04',
+            'base_image_prefix': 'ubuntu-1404',
+            'base_image_project': 'ubuntu-os-cloud',
             # 'username': 'root',
             # 'disk_name': '',
             # 'disk_size': '48',

--- a/fabfile.py
+++ b/fabfile.py
@@ -87,18 +87,28 @@ def destroy():
     data = load_state_from_disk()
     cloud_type = data['cloud_type']
     distribution = data['distribution'] + data['os_release']['VERSION_ID']
-    region = data['region']
-    access_key_id = C[cloud_type][distribution]['access_key_id']
-    secret_access_key = C[cloud_type][distribution]['secret_access_key']
-    instance_id = data['id']
     env.user = data['username']
     env.key_filename = C[cloud_type][distribution]['key_filename']
 
-    f_destroy(cloud=cloud_type,
-              region=region,
-              instance_id=instance_id,
-              access_key_id=access_key_id,
-              secret_access_key=secret_access_key)
+    if cloud_type == 'gce':
+        zone = data['zone']
+        project = data['project']
+        disk_name = data['instance_name']
+        f_destroy(cloud='gce',
+                  zone=zone,
+                  project=project,
+                  disk_name=disk_name)
+    else:
+        region = data['region']
+        access_key_id = C[cloud_type][distribution]['access_key_id']
+        secret_access_key = C[cloud_type][distribution]['secret_access_key']
+        instance_id = data['id']
+
+        f_destroy(cloud=cloud_type,
+                  region=region,
+                  instance_id=instance_id,
+                  access_key_id=access_key_id,
+                  secret_access_key=secret_access_key)
 
 
 @task
@@ -489,27 +499,19 @@ if 'rackspace' in list_of_clouds:
 
 if 'gce' in list_of_clouds:
     C['gce'] = {
-        # 'centos7': {
-        #     "base_image": "centos-7"
-
-            # 'username': 'root',
-            # 'disk_name': '',
-            # 'disk_size': '48',
-            # 'instance_type': rackspace_flavor,
-            # 'key_pair': rackspace_key_pair,
-            # 'region': rackspace_region,
-            # 'secret_access_key': rackspace_password,
-            # 'access_key_id': rackspace_username,
-            # 'security_groups': '',
-            # 'instance_name': 'jenkins_slave_centos7_ondemand',
-            # 'description': 'jenkins_slave_centos7_ondemand',
-            # 'public_key': rackspace_public_key,
-            # 'auth_system': rackspace_auth_system,
-            # 'tenant': rackspace_tenant_name,
-            # 'auth_url': rackspace_auth_url,
-            # 'key_filename': rackspace_key_filename,
-            # 'tags': {'name': 'jenkins_slave_centos7_ondemand'}
-        # },
+        'centos7': {
+            'creation_args': {
+                'base_image_prefix': 'centos-7',
+                'base_image_project': 'centos-cloud',
+                'username': 'ci-slave-image-preper',
+                'project': gce_project,
+                'zone': gce_zone,
+                'machine_type': gce_machine_type,
+                'public_key': gce_public_key,
+            },
+            'key_filename': gce_private_key_filename,
+            'description': 'jenkins-slave-centos7-ondemand',
+        },
         'ubuntu14.04': {
             'creation_args': {
                 'base_image_prefix': 'ubuntu-1404',
@@ -522,20 +524,6 @@ if 'gce' in list_of_clouds:
             },
             'key_filename': gce_private_key_filename,
             'description': 'jenkins-slave-ubuntu14-ondemand',
-            # 'disk_name': '',
-            # 'disk_size': '48',
-            # 'instance_type': rackspace_flavor,
-            # 'key_pair': rackspace_key_pair,
-            # 'region': rackspace_region,
-            # 'secret_access_key': rackspace_password,
-            # 'access_key_id': rackspace_username,
-            # 'security_groups': '',
-            # 'instance_name': 'jenkins_slave_ubuntu14_ondemand',
-            # 'public_key': rackspace_public_key,
-            # 'auth_system': rackspace_auth_system,
-            # 'tenant': rackspace_tenant_name,
-            # 'auth_url': rackspace_auth_url,
-            # 'tags': {'name': 'jenkins_slave_ubuntu14_ondemand'}
         }
     }
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -10,6 +10,7 @@
 import os
 import sys
 from datetime import datetime
+import uuid
 from fabric.api import task, env
 
 from bookshelf.api_v1 import (status as f_status,
@@ -197,7 +198,15 @@ def help():
             # OS_AUTH_URL (optional)
             # OS_REGION_NAME (optional)
 
-            metadata state is stored locally in state.json.
+            For Google Compute Engine (GCE):
+            # GCE_PUBLIC_KEY (Absolute file path to a public ssh key to use)
+            # GCE_PRIVATE_KEY (Absolute file path to a private ssh key to use)
+            # GCE_PROJECT (The GCE project to create the image in)
+            # GCE_ZONE (The GCE zone to use to make the image)
+            # GCE_MACHINE_TYPE (The machine type to use to make the image,
+              defaults to n1-standard-2)
+
+            Metadata state is stored locally in data.json.
           """)
 
 
@@ -350,10 +359,8 @@ def startup_gce_jenkins_slave(cloud, slave_image):
 
     if 'ubuntu' in slave_image:
         distribution = 'ubuntu14.04'
-        #username = 'ubuntu'
     elif 'centos' in slave_image:
         distribution = 'centos7'
-        #username = 'centos7'
     else:
         raise RuntimeError("could not parse distribution from image"
                            "{}".format(slave_image))
@@ -361,7 +368,9 @@ def startup_gce_jenkins_slave(cloud, slave_image):
     jenkins_public_key = (segredos()['env']['default']['ssh']['ssh_keys']
                           [1]['contents'][0])
     username = 'jenkins'
-    f_startup_gce_instance(creation_args['project'],
+    instance_name = u"jenkins-slave-image-" + unicode(uuid.uuid4())
+    f_startup_gce_instance(instance_name,
+                           creation_args['project'],
                            creation_args['zone'],
                            username,
                            creation_args['machine_type'],

--- a/fabfile.py
+++ b/fabfile.py
@@ -350,26 +350,22 @@ def startup_gce_jenkins_slave(cloud, slave_image):
 
     if 'ubuntu' in slave_image:
         distribution = 'ubuntu14.04'
+        #username = 'ubuntu'
     elif 'centos' in slave_image:
         distribution = 'centos7'
+        #username = 'centos7'
     else:
         raise RuntimeError("could not parse distribution from image"
                            "{}".format(slave_image))
-
-    print "hello"
     creation_args = C[cloud][distribution]['creation_args']
     jenkins_public_key = (segredos()['env']['default']['ssh']['ssh_keys']
-                          [1]['contents'])
-    # gce gets the username from the public key, lets make the username
-    # jenkins as that's what jenkins expects by default
-    jenkins_public_key = jenkins_public_key.replace('jenkins-master',
-                                                    'jenkins')
-    import pdb; pdb.set_trace()
+                          [1]['contents'][0])
+    username = 'jenkins'
     f_startup_gce_instance(creation_args['project'],
                            creation_args['zone'],
-                           creation_args['username'],
+                           username,
                            creation_args['machine_type'],
-                           creation_args['slave_image'],
+                           slave_image,
                            jenkins_public_key)
 
 """

--- a/lib/bootstrap.py
+++ b/lib/bootstrap.py
@@ -120,13 +120,14 @@ def bootstrap(distribution):
 
         # some flocker acceptance tests fail when we don't have
         # a know_hosts file
+        sudo("mkdir -p /root/.ssh")
         sudo("touch /root/.ssh/known_hosts")
 
         # generate a id_rsa_flocker
         sudo("test -e  $HOME/.ssh/id_rsa_flocker || ssh-keygen -N '' "
              "-f $HOME/.ssh/id_rsa_flocker")
 
-        # and fix perms on /root/,ssh
+        # and fix perms on /root/.ssh
         sudo("chmod -R 0600 /root/.ssh")
 
         # TODO: this may not be needed, as packaging is done on a docker img
@@ -247,13 +248,14 @@ def bootstrap_jenkins_slave_centos7():
 
         # some flocker acceptance tests fail when we don't have
         # a know_hosts file
+        sudo("mkdir -p /root/.ssh")
         sudo("touch /root/.ssh/known_hosts")
 
         # generate a id_rsa_flocker
         sudo("test -e  $HOME/.ssh/id_rsa_flocker || ssh-keygen -N '' "
              "-f $HOME/.ssh/id_rsa_flocker")
 
-        # and fix perms on /root/,ssh
+        # and fix perms on /root/.ssh
         sudo("chmod -R 0600 /root/.ssh")
 
         # TODO: this may not be needed, as packaging is done on a docker img
@@ -343,13 +345,14 @@ def bootstrap_jenkins_slave_ubuntu14():
 
         # some flocker acceptance tests fail when we don't have
         # a know_hosts file
+        sudo("mkdir -p /root/.ssh")
         sudo("touch /root/.ssh/known_hosts")
 
         # generate a id_rsa_flocker
         sudo("test -e  $HOME/.ssh/id_rsa_flocker || ssh-keygen -N '' "
              "-f $HOME/.ssh/id_rsa_flocker")
 
-        # and fix perms on /root/,ssh
+        # and fix perms on /root/.ssh
         sudo("chmod -R 0600 /root/.ssh")
 
         apt_install_from_url('rpmlint',

--- a/lib/mycookbooks.py
+++ b/lib/mycookbooks.py
@@ -79,7 +79,11 @@ def check_for_missing_environment_variables(cloud_type=None):
                                 'OS_REGION_NAME',
                                 'RACKSPACE_KEY_PAIR',
                                 'RACKSPACE_KEY_FILENAME',
-                                'OS_NO_CACHE']}
+                                'OS_NO_CACHE'],
+
+                  'gce': ['GCE_PRIVATE_KEY',
+                          'GCE_PUBLIC_KEY'],
+                  }
 
     for cloud in cloud_type:
         if not set(cloud_vars[cloud]).issubset(set(os.environ)):
@@ -152,6 +156,8 @@ def get_cloud_environment():
             clouds.append('ec2')
         if 'cloud=rackspace' in action:
             clouds.append('rackspace')
+        if 'cloud=gce' in action:
+            clouds.append('gce')
     return clouds
 
 

--- a/lib/mycookbooks.py
+++ b/lib/mycookbooks.py
@@ -34,7 +34,8 @@ from bookshelf.api_v1 import (dir_ensure,
                               reboot,
                               yum_install)
 from bookshelf.api_v1 import (rackspace as f_rackspace,
-                              ec2 as f_ec2)
+                              ec2 as f_ec2,
+                              gce as f_gce)
 
 
 def add_user_to_docker_group():
@@ -103,6 +104,14 @@ def create_etc_slave_config():
 
 def ec2():
     f_ec2()
+
+
+def gce():
+    f_gce()
+
+
+def rackspace():
+    f_rackspace()
 
 
 def fix_umask():
@@ -185,13 +194,6 @@ def local_docker_images():
                 'clusterhqci/fpm-ubuntu-trusty',
                 'clusterhqci/fpm-ubuntu-vivid',
                 'clusterhqci/fpm-centos-7']
-
-
-def rackspace():
-    f_rackspace()
-    # Rackspace servers use root instead of the 'centos/ubuntu'
-    # when they first boot.
-    env.user = 'root'
 
 
 def segredos():

--- a/tests/acceptance.py
+++ b/tests/acceptance.py
@@ -21,68 +21,26 @@ from lib.bootstrap import (local_docker_images,
                            centos7_required_packages)
 
 
-def acceptance_tests(cloud,
-                     region,
-                     instance_id,
-                     access_key_id,
-                     secret_access_key,
-                     distribution,
-                     username):
+def acceptance_tests(distribution):
     """ proxy function that calls acceptance tests for speficic OS
 
-    :param string cloud: The cloud type to use 'ec2', 'rackspace'
-    :param string region: Cloud provider's region to deploy instance
-    :param string instance_id: The VM id as known by the cloud provider
-    :param string access_key_id: Typically the API access key
-    :param string secret_access_key: The secret matching the access key
     :param string distribution: which OS to use 'centos7', 'ubuntu1404'
-    :param string username: ssh username to use
     """
 
     # run common tests for all platforms
-    acceptance_tests_common_tests_for_flocker(cloud,
-                                              region,
-                                              instance_id,
-                                              access_key_id,
-                                              secret_access_key,
-                                              distribution,
-                                              username)
+    acceptance_tests_common_tests_for_flocker(distribution)
 
     if 'ubuntu' in distribution.lower():
-        acceptance_tests_on_ubuntu14_img_for_flocker(cloud,
-                                                     region,
-                                                     instance_id,
-                                                     access_key_id,
-                                                     secret_access_key,
-                                                     distribution,
-                                                     username)
+        acceptance_tests_on_ubuntu14_img_for_flocker(distribution)
 
     if 'centos' in distribution.lower():
-        acceptance_tests_on_centos7_img_for_flocker(cloud,
-                                                    region,
-                                                    instance_id,
-                                                    access_key_id,
-                                                    secret_access_key,
-                                                    distribution,
-                                                    username)
+        acceptance_tests_on_centos7_img_for_flocker(distribution)
 
 
-def acceptance_tests_common_tests_for_flocker(cloud,
-                                              region,
-                                              instance,
-                                              access_key_id,
-                                              secret_access_key,
-                                              distribution,
-                                              username):
+def acceptance_tests_common_tests_for_flocker(distribution):
     """ Runs checks that are common to all platforms related to Flocker
 
-    :param string cloud: The cloud type to use 'ec2', 'rackspace'
-    :param string region: Cloud provider's region to deploy instance
-    :param string instance_id: The VM id as known by the cloud provider
-    :param string access_key_id: Typically the API access key
-    :param string secret_access_key: The secret matching the access key
     :param string distribution: which OS to use 'centos7', 'ubuntu1404'
-    :param string username: ssh username to use
     """
 
     ec2_host = "%s@%s" % (env.user, load_state_from_disk()['ip_address'])
@@ -176,23 +134,11 @@ def acceptance_tests_common_tests_for_flocker(cloud,
         assert process.is_up("docker")
 
 
-def acceptance_tests_on_centos7_img_for_flocker(cloud,
-                                                region,
-                                                instance,
-                                                access_key_id,
-                                                secret_access_key,
-                                                distribution,
-                                                username):
+def acceptance_tests_on_centos7_img_for_flocker(distribution):
     """ checks that the CentOS 7 image is suitable for running the Flocker
     acceptance tests
 
-    :param string cloud: The cloud type to use 'ec2', 'rackspace'
-    :param string region: Cloud provider's region to deploy instance
-    :param string instance_id: The VM id as known by the cloud provider
-    :param string access_key_id: Typically the API access key
-    :param string secret_access_key: The secret matching the access key
     :param string distribution: which OS to use 'centos7', 'ubuntu1404'
-    :param string username: ssh username to use
     """
 
     ec2_host = "%s@%s" % (env.user, load_state_from_disk()['ip_address'])
@@ -267,23 +213,11 @@ def acceptance_tests_on_centos7_img_for_flocker(cloud,
         assert sudo("systemctl is-enabled docker")
 
 
-def acceptance_tests_on_ubuntu14_img_for_flocker(cloud,
-                                                 region,
-                                                 instance,
-                                                 access_key_id,
-                                                 secret_access_key,
-                                                 distribution,
-                                                 username):
+def acceptance_tests_on_ubuntu14_img_for_flocker(distribution):
     """ checks that the Ubuntu 14 image is suitable for running the Flocker
     acceptance tests
 
-        :param string cloud: The cloud type to use 'ec2', 'rackspace'
-        :param string region: Cloud provider's region to deploy instance
-        :param string instance_id: The VM id as known by the cloud provider
-        :param string access_key_id: Typically the API access key
-        :param string secret_access_key: The secret matching the access key
         :param string distribution: which OS to use 'centos7', 'ubuntu1404'
-        :param string username: ssh username to use
     """
 
     ec2_host = "%s@%s" % (env.user, load_state_from_disk()['ip_address'])


### PR DESCRIPTION
We simply slotted in GCE support.  This works in tandem with the changes in https://github.com/ClusterHQ/bookshelf/pull/2